### PR TITLE
Fix config file

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -11,9 +11,9 @@ static const char *prompt      = NULL;      /* -p  option; prompt to the left of
 /* Colour scheme */
 static const char *colors[SchemeLast][2] = {
 	/*     fg         bg       */
-	[SchemeNorm] = { "#bbbbbb", "#222222" },
-	[SchemeSel] = { "#eeeeee", "#005577" },
-	[SchemeOut] = { "#000000", "#00ffff" },
+	[SchemeNorm] = { "#f8f8f2", "#282a36" },
+	[SchemeSel] = { "#f8f8f2", "#6272a4" },
+	[SchemeOut] = { "#f8f8f2", "#bd93f9" },
 };
 /* -l option; if nonzero, dmenu uses vertical list with given number of lines */
 static unsigned int lines      = 0;


### PR DESCRIPTION
Fixes #1 
- [x] Fix colors in the dmenu config file
- [x] Follow dracula theme color palette for background and foreground colors 

## Screenshots
### dmenu with dracula applied:
![image](https://github.com/dracula/dmenu/assets/86654557/06c68707-1dff-4c61-8d56-42cc07ea94df)

### Changed code:
![image](https://github.com/dracula/dmenu/assets/86654557/bf9b2c5d-66c4-44c4-800b-1e853eae69dc)